### PR TITLE
fix: use the american english type of cancelled

### DIFF
--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -323,7 +323,7 @@ func (r *basePoolManager) startLoopForFunction(f func() error, interval time.Dur
 				// this worker was stopped.
 				return
 			default:
-				r.waitForTimeoutOrCanceled(common.BackoffTimer)
+				r.waitForTimeoutOrCancelled(common.BackoffTimer)
 			}
 		}
 	}
@@ -841,7 +841,7 @@ func (r *basePoolManager) Status() params.PoolManagerStatus {
 	}
 }
 
-func (r *basePoolManager) waitForTimeoutOrCanceled(timeout time.Duration) {
+func (r *basePoolManager) waitForTimeoutOrCancelled(timeout time.Duration) {
 	slog.DebugContext(
 		r.ctx, fmt.Sprintf("sleeping for %.2f minutes", timeout.Minutes()))
 	select {
@@ -956,9 +956,9 @@ func (r *basePoolManager) getRunnerDetailsFromJob(job params.WorkflowJob) (param
 
 	var err error
 	if job.WorkflowJob.RunnerName == "" {
-		if job.WorkflowJob.Conclusion == "skipped" || job.WorkflowJob.Conclusion == "canceled" {
-			// job was skipped or canceled before a runner was allocated. No point in continuing.
-			return params.RunnerInfo{}, fmt.Errorf("job %d was skipped or canceled before a runner was allocated: %w", job.WorkflowJob.ID, runnerErrors.ErrNotFound)
+		if job.WorkflowJob.Conclusion == "skipped" || job.WorkflowJob.Conclusion == "cancelled" {
+			// job was skipped or cancelled before a runner was allocated. No point in continuing.
+			return params.RunnerInfo{}, fmt.Errorf("job %d was skipped or cancelled before a runner was allocated: %w", job.WorkflowJob.ID, runnerErrors.ErrNotFound)
 		}
 		// Runner name was not set in WorkflowJob by github. We can still attempt to
 		// fetch the info we need, using the workflow run ID, from the API.
@@ -1020,7 +1020,7 @@ func (r *basePoolManager) paramsWorkflowJobToParamsJob(job params.WorkflowJob) (
 
 	runnerName := job.WorkflowJob.RunnerName
 	if job.Action != "queued" && runnerName == "" {
-		if job.WorkflowJob.Conclusion != "skipped" && job.WorkflowJob.Conclusion != "canceled" {
+		if job.WorkflowJob.Conclusion != "skipped" && job.WorkflowJob.Conclusion != "cancelled" {
 			// Runner name was not set in WorkflowJob by github. We can still attempt to fetch the info we need,
 			// using the workflow run ID, from the API.
 			// We may still get no runner name. In situations such as jobs being cancelled before a runner had the chance


### PR DESCRIPTION
github is sending job events where conclusion=cancelled is spelled in american english.